### PR TITLE
Change podspec source to make cocoapods happy

### DIFF
--- a/Tangram-es.podspec
+++ b/Tangram-es.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.documentation_url = 'https://mapzen.com/documentation/tangram/'
 
   s.source = {
-    :path => "."
+    :git => 'https://github.com/tangrams/ios-framework.git', :tag => "v#{s.version}"
   }
 
   s.platform              = :ios


### PR DESCRIPTION
Apparently :path was removed in 1.1.0 update but not for private builds, i.e. this no longer works for trunk pods. 